### PR TITLE
CHange required tf version fixed to 2.1

### DIFF
--- a/src/PeerRead/model/run_causal_bert.py
+++ b/src/PeerRead/model/run_causal_bert.py
@@ -206,7 +206,7 @@ def make_dragonnet_metrics():
 
 def main(_):
     # Users should always run this script under TF 2.x
-    assert tf.version.VERSION.startswith('2.1')
+    assert tf.version.VERSION.startswith('2.')
     tf.random.set_seed(FLAGS.seed)
 
     # with tf.io.gfile.GFile(FLAGS.input_meta_data_path, 'rb') as reader:


### PR DESCRIPTION
This fixes the problem of trying to run the code in later tf versions as it's not possible to select a specific "subversion" of tf.